### PR TITLE
Add messages for repo error

### DIFF
--- a/git_version/templatetags/git_tags.py
+++ b/git_version/templatetags/git_tags.py
@@ -1,7 +1,11 @@
+import logging
 from django import template
 from git import Repo
 
+logger = logging.getLogger(__name__)
+
 register = template.Library()
+
 
 @register.simple_tag
 def current_commit(path):
@@ -11,9 +15,11 @@ def current_commit(path):
         chash = commit.hexsha
         repo.__del__()
         return chash
-    except Exception:
-        print(f"git_version - trouble with repo path {path}")
+    except Exception as e:
+        logger.debug(f"Failed to find current commit for {path}")
+        logger.debug(f"Exception was: {e}")
         return "no git?"
+
 
 @register.simple_tag
 def current_commit_short(path):

--- a/git_version/templatetags/git_tags.py
+++ b/git_version/templatetags/git_tags.py
@@ -5,11 +5,15 @@ register = template.Library()
 
 @register.simple_tag
 def current_commit(path):
-    repo = Repo(path)
-    commit = repo.commit()
-    chash = commit.hexsha
-    repo.__del__()
-    return chash
+    try:
+        repo = Repo(path)
+        commit = repo.commit()
+        chash = commit.hexsha
+        repo.__del__()
+        return chash
+    except Exception:
+        print(f"git_version - trouble with repo path {path}")
+        return "no git?"
 
 @register.simple_tag
 def current_commit_short(path):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     author='Daniel Seiler',
     author_email='daniel.seiler@fachschaft.informatik.tu-darmstadt.de',
     install_requires=[
-        'django<4',
+        'django<5',
         'gitpython',
     ],
     classifiers=[


### PR DESCRIPTION
If a working app is plopped into a container, there is no .git dir, so the Repo() access raises an exception.
This prints a minimal error message, and a clue to the UI why the commit may not show.